### PR TITLE
Actual multithreading in stitch_render-client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ docs/*.sec
 # VS code stuff
 *.code-workspace
 .vscode/*
+
+# do not sync logs
+logs/

--- a/notebooks/stitch_render-client.ipynb
+++ b/notebooks/stitch_render-client.ipynb
@@ -14,21 +14,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 1,
    "id": "a9f1c1f9-f144-493d-b6bc-69b97102f1a6",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# indirectly enable autocomplete\n",
     "%config Completer.use_jedi = False\n",
@@ -40,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 2,
    "id": "9775c083-9d1d-4542-8b1a-11552e0faa77",
    "metadata": {
     "tags": []
@@ -67,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 3,
    "id": "4c79b07f-5658-4a24-8743-9a71b0b06e01",
    "metadata": {
     "tags": []
@@ -79,14 +70,15 @@
     "sesh = requests.Session()\n",
     "sesh.auth = auth\n",
     "\n",
+    "project = \"20240222_RL019_hoechst_exocrine\"\n",
     "# render-ws environment variables\n",
     "params_render = {\n",
     "    \"host\": \"http://localhost\",\n",
     "    \"port\": 8081,\n",
     "    \"client_scripts\": \"/home/catmaid/render/render-ws-java-client/src/main/scripts\",\n",
     "    \"client_script\": \"/home/catmaid/render/render-ws-java-client/src/main/scripts/run_ws_client.sh\",\n",
-    "    \"owner\": \"akievits\",\n",
-    "    \"project\": \"20230914_RP_exocrine_partial_test\",\n",
+    "    \"owner\": \"skaracoban\",\n",
+    "    \"project\": project,\n",
     "    \"session\": sesh\n",
     "}\n",
     "\n",
@@ -95,14 +87,14 @@
     "    \"port\": 8081,\n",
     "    \"client_scripts\": \"/home/catmaid/render/render-ws-java-client/src/main/scripts\",\n",
     "    \"client_script\": \"/home/catmaid/render/render-ws-java-client/src/main/scripts/run_ws_client.sh\",\n",
-    "    \"owner\": \"akievits\",\n",
-    "    \"project\": \"20230914_RP_exocrine_partial_test\",\n",
+    "    \"owner\": \"skaracoban\",\n",
+    "    \"project\": project,\n",
     "    \"memGB\": '2G', # Allocate enough memory\n",
     "    \"session\": sesh\n",
     "}\n",
     "\n",
     "# set project directory\n",
-    "dir_project = pathlib.Path(\"/long_term_storage/akievits/FAST-EM/20230914_RP_exocrine_partial_test/\")\n",
+    "dir_project = pathlib.Path(\"/long_term_storage/akievits/FAST-EM/20240222_RL019_hoechst_exocrine/\")\n",
     "\n",
     "# set max_workers (for multithreading)\n",
     "max_workers = 20"
@@ -124,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 4,
    "id": "b45f7d85-e39d-4eab-a5a8-eb1280d2c812",
    "metadata": {
     "tags": []
@@ -134,28 +126,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of tile pairs... 120 \n",
+      "Number of tile pairs... 264 \n",
       "---------------------------\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "[['t00_z0_y4_x4', 't05_z0_y3_x4'],\n",
-       " ['t00_z0_y4_x4', 't01_z0_y4_x3'],\n",
-       " ['t01_z0_y4_x3', 't06_z0_y3_x3'],\n",
-       " ['t01_z0_y4_x3', 't02_z0_y4_x2'],\n",
-       " ['t02_z0_y4_x2', 't07_z0_y3_x2']]"
+       "[['aaa_aaa_EM_himag-S001-00000x00011', 'aax_aax_EM_himag-S001-00000x00010'],\n",
+       " ['aaa_aaa_EM_himag-S001-00000x00011', 'aab_aab_EM_himag-S001-00001x00011'],\n",
+       " ['aab_aab_EM_himag-S001-00001x00011', 'aaw_aaw_EM_himag-S001-00001x00010'],\n",
+       " ['aab_aab_EM_himag-S001-00001x00011', 'aac_aac_EM_himag-S001-00002x00011'],\n",
+       " ['aac_aac_EM_himag-S001-00002x00011', 'aav_aav_EM_himag-S001-00002x00010']]"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# choose stack from which to get tile pairs\n",
-    "stack = \"postcorrection\"\n",
+    "stack = \"EM_himag\"\n",
     "z_values = [int(z) for z in renderapi.stack.get_z_values_for_stack(\n",
     "    stack,\n",
     "    **params_render\n",
@@ -198,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 5,
    "id": "dbffce13-8eed-4073-a47b-5db91418b835",
    "metadata": {
     "tags": []
@@ -214,7 +206,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 6,
    "id": "c10bf3f9-049a-4670-a91c-4fd7a4fb537c",
    "metadata": {
     "tags": []
@@ -223,10 +215,10 @@
     {
      "data": {
       "text/plain": [
-       "'20230914_RP_exocrine_partial_test_postcorrection_stitch_matches'"
+       "'20240222_RL019_hoechst_exocrine_EM_himag_stitch_matches'"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -239,7 +231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -257,7 +249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 8,
    "id": "53325649-5850-4986-9b46-4c46c0329b8f",
    "metadata": {
     "tags": []
@@ -285,7 +277,7 @@
        " 'clipHeight': 640}"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -336,7 +328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -345,18 +337,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ad8e06ff194742fa9f8592a433cf56c5",
+       "model_id": "d69c056e47c44b259744144f5da80e49",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "extracting point matches:   0%|          | 0/120 [00:00<?, ?tilepairs/s]"
+       "submitting tile pairs:   0%|          | 0/264 [00:00<?, ?tilepairs/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "591037aafc7d4b68b2097c5bb091c9c7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "extracting point matches:   0%|          | 0/264 [00:00<?, ?tilepairs/s]"
       ]
      },
      "metadata": {},
@@ -369,11 +375,16 @@
     "executor = concurrent.futures.ThreadPoolExecutor(\n",
     "max_workers = max_workers\n",
     ")\n",
+    "\n",
     "try:\n",
-    "    for tile_pair, pos in zip(tile_pairs_reformat, relativePositions):\n",
+    "    for tile_pair, pos in tqdm(zip(tile_pairs_reformat, relativePositions),\n",
+    "                               desc=\"submitting tile pairs\",\n",
+    "                               total=len(tile_pairs_reformat),\n",
+    "                               unit=\"tilepairs\",\n",
+    "                               smoothing=0.3):\n",
     "        params_SIFT.firstCanvasPosition = pos\n",
     "        future = executor.submit(\n",
-    "            renderapi.client.pointMatchClient(\n",
+    "            renderapi.client.pointMatchClient,\n",
     "                stack=stack,\n",
     "                collection=match_collection,\n",
     "                tile_pairs=[tile_pair],\n",
@@ -381,7 +392,6 @@
     "                excludeAllTransforms=True,\n",
     "                subprocess_mode='check_output',  # suppresses output\n",
     "                **params_align)\n",
-    "        )\n",
     "        futures.add(future)\n",
     "\n",
     "    for future in tqdm(\n",
@@ -409,7 +419,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "5cd8c09e-f2ff-4c80-87e3-f7c430948b31",
    "metadata": {
     "tags": []
@@ -452,7 +462,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "705e9814-1905-4edb-b21d-d456f2abe054",
    "metadata": {
     "tags": []
@@ -468,7 +478,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "36d903ec-2bd7-4b61-839e-c0d896dac411",
    "metadata": {
     "tags": []
@@ -580,7 +590,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "3dc48cc5-1e99-46ee-8646-5f2e0e7f0dc8",
    "metadata": {
     "tags": []
@@ -662,7 +672,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "ef74803c-dff3-4315-9e10-484de54ff937",
    "metadata": {
     "tags": []
@@ -723,7 +733,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/stitch_render-client.ipynb
+++ b/notebooks/stitch_render-client.ipynb
@@ -58,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 13,
    "id": "4c79b07f-5658-4a24-8743-9a71b0b06e01",
    "metadata": {
     "tags": []
@@ -94,7 +94,7 @@
     "}\n",
     "\n",
     "# set project directory\n",
-    "dir_project = pathlib.Path(\"/long_term_storage/akievits/FAST-EM/20240222_RL019_hoechst_exocrine/\")\n",
+    "dir_project = pathlib.Path(\"/long_term_storage/skaracoban/data/test_data/20240222_RL019_hoechst_exocrine\")\n",
     "\n",
     "# set max_workers (for multithreading)\n",
     "max_workers = 20"
@@ -419,21 +419,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "5cd8c09e-f2ff-4c80-87e3-f7c430948b31",
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "grid shape: (10, 10)\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "37dac89050064e828c3d96633cd87f66",
+       "model_id": "9b541d7d3d4a4c8fb0448436aee3eccc",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "interactive(children=(IntSlider(value=0, description='z', max=2), Output()), _dom_classes=('widget-interact',)…"
+       "interactive(children=(IntSlider(value=0, description='z', max=0), Output()), _dom_classes=('widget-interact',)…"
       ]
      },
      "metadata": {},
@@ -462,7 +469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "705e9814-1905-4edb-b21d-d456f2abe054",
    "metadata": {
     "tags": []
@@ -478,7 +485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "36d903ec-2bd7-4b61-839e-c0d896dac411",
    "metadata": {
     "tags": []
@@ -488,8 +495,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/long_term_storage/akievits/FAST-EM/20230914_RP_exocrine_partial_test/_jsons_montage/postcorrection/montage.json\n",
-      "----------------------------------------------------------------------------------------------------------------\n",
+      "/long_term_storage/skaracoban/data/test_data/20240222_RL019_hoechst_exocrine/_jsons_montage/EM_himag/montage.json\n",
+      "-----------------------------------------------------------------------------------------------------------------\n",
       "{'close_stack': 'True',\n",
       " 'first_section': 0.0,\n",
       " 'hdf5_options': {'chunks_per_file': -1, 'output_dir': ''},\n",
@@ -497,11 +504,11 @@
       "                 'collection_type': 'stack',\n",
       "                 'db_interface': 'render',\n",
       "                 'host': 'http://localhost',\n",
-      "                 'name': 'postcorrection',\n",
-      "                 'owner': 'akievits',\n",
+      "                 'name': 'EM_himag',\n",
+      "                 'owner': 'skaracoban',\n",
       "                 'port': 8081,\n",
-      "                 'project': '20230914_RP_exocrine_partial_test'},\n",
-      " 'last_section': 2.0,\n",
+      "                 'project': '20240222_RL019_hoechst_exocrine'},\n",
+      " 'last_section': 0.0,\n",
       " 'log_level': 'INFO',\n",
       " 'matrix_assembly': {'cross_pt_weight': 1.0,\n",
       "                     'depth': 2,\n",
@@ -514,16 +521,16 @@
       "                  'collection_type': 'stack',\n",
       "                  'db_interface': 'render',\n",
       "                  'host': 'http://localhost',\n",
-      "                  'name': 'postcorrection_stitched',\n",
-      "                  'owner': 'akievits',\n",
+      "                  'name': 'EM_himag_stitched',\n",
+      "                  'owner': 'skaracoban',\n",
       "                  'port': 8081,\n",
-      "                  'project': '20230914_RP_exocrine_partial_test'},\n",
+      "                  'project': '20240222_RL019_hoechst_exocrine'},\n",
       " 'pointmatch': {'client_scripts': '/home/catmaid/render/render-ws-java-client/src/main/scripts',\n",
       "                'collection_type': 'pointmatch',\n",
       "                'db_interface': 'render',\n",
       "                'host': 'http://localhost',\n",
-      "                'name': '20230914_RP_exocrine_partial_test_postcorrection_matches',\n",
-      "                'owner': 'akievits',\n",
+      "                'name': '20240222_RL019_hoechst_exocrine_EM_himag_stitch_matches',\n",
+      "                'owner': 'skaracoban',\n",
       "                'port': 8081},\n",
       " 'regularization': {'default_lambda': 0.005,\n",
       "                    'thinplate_factor': 1e-05,\n",
@@ -590,7 +597,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "3dc48cc5-1e99-46ee-8646-5f2e0e7f0dc8",
    "metadata": {
     "tags": []
@@ -600,58 +607,30 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/akievits/interactive-render-workflow/.venv/lib/python3.9/site-packages/argschema/utils.py:346: FutureWarning: '--transform_apply' is using old-style command-line syntax with each element as a separate argument. This will not be supported in argschema after 2.0. See http://argschema.readthedocs.io/en/master/user/intro.html#command-line-specification for details.\n",
+      "/home/skaracoban/miniconda3/envs/render/lib/python3.10/site-packages/argschema/utils.py:346: FutureWarning: '--transform_apply' is using old-style command-line syntax with each element as a separate argument. This will not be supported in argschema after 2.0. See http://argschema.readthedocs.io/en/master/user/intro.html#command-line-specification for details.\n",
       "  warnings.warn(warn_msg, FutureWarning)\n",
       "INFO:bigfeta.utils:\n",
-      " loaded 25 tile specs from 1 zvalues in 0.0 sec using interface: render\n",
-      "INFO:__main__: A created in 0.2 seconds\n",
+      " loaded 144 tile specs from 1 zvalues in 0.1 sec using interface: render\n",
+      "INFO:__main__: A created in 0.5 seconds\n",
       "INFO:__main__:\n",
-      " solved in 0.0 sec\n",
-      " precision [norm(Kx-Lm)/norm(Lm)] = 5.7e-16, 1.2e-15\n",
-      " error     [norm(Ax-b)] = 459.985, 347.522\n",
-      " [mean(Ax) +/- std(Ax)] : 0.0 +/- 8.4, 0.0 +/- 6.3\n",
-      " [mean(error mag) +/- std(error mag)] : 9.1 +/- 5.2\n",
-      "INFO:__main__:\n",
-      " scales: 1.00 +/- 0.00, 1.00 +/- 0.00\n",
-      "INFO:bigfeta.utils:\n",
-      "ingesting results to http://localhost:8081 akievits__20230914_RP_exocrine_partial_test__postcorrection_stitched\n",
-      "INFO:bigfeta.utils:render output is going to /dev/null\n",
-      "INFO:bigfeta.utils:\n",
-      " loaded 25 tile specs from 1 zvalues in 0.0 sec using interface: render\n",
-      "INFO:__main__: A created in 0.1 seconds\n",
-      "INFO:__main__:\n",
-      " solved in 0.0 sec\n",
-      " precision [norm(Kx-Lm)/norm(Lm)] = 8.1e-16, 7.5e-16\n",
-      " error     [norm(Ax-b)] = 192.756, 221.827\n",
-      " [mean(Ax) +/- std(Ax)] : 0.0 +/- 3.3, 0.0 +/- 3.7\n",
-      " [mean(error mag) +/- std(error mag)] : 4.3 +/- 2.5\n",
+      " solved in 0.1 sec\n",
+      " precision [norm(Kx-Lm)/norm(Lm)] = 3.3e-16, 6.8e-16\n",
+      " error     [norm(Ax-b)] = 979.498, 1190.968\n",
+      " [mean(Ax) +/- std(Ax)] : 0.2 +/- 5.5, 2.3 +/- 6.2\n",
+      " [mean(error mag) +/- std(error mag)] : 7.5 +/- 4.1\n",
       "INFO:__main__:\n",
       " scales: 1.00 +/- 0.00, 1.00 +/- 0.00\n",
       "INFO:bigfeta.utils:\n",
-      "ingesting results to http://localhost:8081 akievits__20230914_RP_exocrine_partial_test__postcorrection_stitched\n",
+      "ingesting results to http://localhost:8081 skaracoban__20240222_RL019_hoechst_exocrine__EM_himag_stitched\n",
       "INFO:bigfeta.utils:render output is going to /dev/null\n",
-      "INFO:bigfeta.utils:\n",
-      " loaded 25 tile specs from 1 zvalues in 0.0 sec using interface: render\n",
-      "INFO:__main__: A created in 0.1 seconds\n",
-      "INFO:__main__:\n",
-      " solved in 0.0 sec\n",
-      " precision [norm(Kx-Lm)/norm(Lm)] = 5.3e-16, 9.6e-16\n",
-      " error     [norm(Ax-b)] = 486.469, 371.960\n",
-      " [mean(Ax) +/- std(Ax)] : 0.0 +/- 8.8, 0.0 +/- 6.7\n",
-      " [mean(error mag) +/- std(error mag)] : 9.5 +/- 5.8\n",
-      "INFO:__main__:\n",
-      " scales: 1.00 +/- 0.00, 1.00 +/- 0.00\n",
-      "INFO:bigfeta.utils:\n",
-      "ingesting results to http://localhost:8081 akievits__20230914_RP_exocrine_partial_test__postcorrection_stitched\n",
-      "INFO:bigfeta.utils:render output is going to /dev/null\n",
-      "INFO:__main__: total time: 5.5\n"
+      "INFO:__main__: total time: 2.6\n"
      ]
     }
    ],
    "source": [
     "# Path to `BigFeta`\n",
     "cwd = Path.cwd().as_posix()\n",
-    "dir_BigFeta = Path('/home/akievits/BigFeta/')\n",
+    "dir_BigFeta = Path('/home/skaracoban/render_code/BigFeta/')\n",
     "\n",
     "# Select json for stitching\n",
     "stitch_json = dir_project / '_jsons_montage' / stack / 'montage.json'\n",
@@ -672,7 +651,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "ef74803c-dff3-4315-9e10-484de54ff937",
    "metadata": {
     "tags": []
@@ -681,7 +660,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "30225fa5fe664e35a4fde0bcdcfb1337",
+       "model_id": "f098969194664ad2bffabe4bcde2e15e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -695,12 +674,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "76273f2fbce14fd096505d069e0a7d93",
+       "model_id": "e58490fa8592498eb2f340d1cf37b3b4",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "interactive(children=(IntSlider(value=0, description='z', max=2), IntSlider(value=26490, description='vmin', m…"
+       "interactive(children=(IntSlider(value=0, description='z', max=0), IntSlider(value=33062, description='vmin', m…"
       ]
      },
      "metadata": {},
@@ -709,7 +688,7 @@
    ],
    "source": [
     "# Plot stacks\n",
-    "stacks = [\"postcorrection\", \"postcorrection_stitched\"]\n",
+    "stacks = [\"EM_himag\", \"EM_himag_stitched\"]\n",
     "plotting.plot_stacks(\n",
     "    stacks,\n",
     "    **params_render\n",


### PR DESCRIPTION
Instead of submitting a job to the executor the stitch_render-client notebook instead called the `renderapi.client.pointMatchClient` instead got called *before* submitting the job. This effectively made the code single-threaded. THis pull request fixes that.

Also added logs to .gitignore